### PR TITLE
Fix apply T0 correction bug

### DIFF
--- a/MuonAlignmentAlgorithms/python/gather_cfg.py
+++ b/MuonAlignmentAlgorithms/python/gather_cfg.py
@@ -249,7 +249,7 @@ if T0_Corr:
     process.load("RecoMuon.GlobalMuonProducer.globalMuons_cfi")
     process.globalMuons.TrackerCollectionLabel = cms.InputTag("ALCARECOMuAlCalIsolatedMuGeneralTracks")
     process.Mymuonlocalreco = cms.Sequence(process.dt4DSegments * process.ancientMuonSeed * process.standAloneMuons * process.globalMuons )
-    process.DTMeantimerPatternReco4DAlgo_LinearDriftFromDB.Reco4DAlgoConfig.performT0SegCorrection = cms.bool(True)
+    process.dt4DSegments.Reco4DAlgoConfig.performT0SegCorrection = cms.bool(True)
 
 if iscosmics:
     process.MuonAlignmentPreFilter.tracksTag = cms.InputTag("ALCARECOMuAlGlobalCosmics:GlobalMuon")


### PR DESCRIPTION
Change "DTMeantimerPatternReco4DAlgo_LinearDriftFromDB" to "dt4DSegments". This is probably required since we are calling process.dt4DSegments in the Sequence above. This change will fix the bug where applyT0corr is not turned on in the Meantimer algorithm (DTMeantimerPatternReco4D.cc).