### PR TITLE
Cmssw 10 0 0 pre2

### DIFF
--- a/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -66,15 +66,15 @@
 class AlignmentMonitorAsAnalyzer : public edm::EDAnalyzer {
    public:
       explicit AlignmentMonitorAsAnalyzer(const edm::ParameterSet&);
-      ~AlignmentMonitorAsAnalyzer();
+      ~AlignmentMonitorAsAnalyzer() override;
 
       typedef std::pair<const Trajectory*, const reco::Track*> ConstTrajTrackPair; 
       typedef std::vector<ConstTrajTrackPair> ConstTrajTrackPairCollection;
 
    private:
-      virtual void beginJob() override;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      void beginJob() override;
+      void analyze(const edm::Event&, const edm::EventSetup&) override;
+      void endJob() override;
 
       // ----------member data ---------------------------
       edm::InputTag m_tjTag;
@@ -103,9 +103,9 @@ class AlignmentMonitorAsAnalyzer : public edm::EDAnalyzer {
 AlignmentMonitorAsAnalyzer::AlignmentMonitorAsAnalyzer(const edm::ParameterSet& iConfig)
    : m_tjTag(iConfig.getParameter<edm::InputTag>("tjTkAssociationMapTag"))
    , m_aliParamStoreCfg(iConfig.getParameter<edm::ParameterSet>("ParameterStore"))
-   , m_alignableTracker(NULL)
-   , m_alignableMuon(NULL)
-   , m_alignmentParameterStore(NULL)
+   , m_alignableTracker(nullptr)
+   , m_alignableMuon(nullptr)
+   , m_alignmentParameterStore(nullptr)
 {
    std::vector<std::string> monitors = iConfig.getUntrackedParameter<std::vector<std::string> >( "monitors" );
 

--- a/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonSystemMap1D.cc
+++ b/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonSystemMap1D.cc
@@ -188,11 +188,9 @@ void AlignmentMonitorMuonSystemMap1D::book()
 {
   std::string wheel_label[5]={"A","B","C","D","E"};
 
-  for (int station = 1; station<=4; station++)
+  for (unsigned char station = 1; station<=4; station++)
   {
-    char c_station[4];
-    sprintf(c_station, "%d", station);
-    std::string s_station(c_station);
+    std::string s_station = std::to_string(station);
     
     bool do_y = true;
     if (station==4) do_y = false;
@@ -230,9 +228,7 @@ void AlignmentMonitorMuonSystemMap1D::book()
       
       for (int ring = 1; ring <= 3; ring++) // the ME1/a (ring4) is not independent from ME1/b (ring1)
       {
-	char c_ring[4];
-	sprintf(c_ring, "%d", ring);
-	std::string s_ring(c_ring);
+	std::string s_ring = std::to_string(ring);
 	if ( (station>1 && ring<=2) || station==1)
         {
 	  m_CSCvsphi_me[endcap-1][station-1][ring-1] = 

--- a/MuonAlignmentAlgorithms/interface/MuonResiduals5DOFFitter.h
+++ b/MuonAlignmentAlgorithms/interface/MuonResiduals5DOFFitter.h
@@ -53,7 +53,7 @@ public:
   };
 
   MuonResiduals5DOFFitter(int residualsModel, int minHits, int useResiduals, bool weightAlignment=true): MuonResidualsFitter(residualsModel, minHits, useResiduals, weightAlignment) {}
-  ~MuonResiduals5DOFFitter(){}
+  ~MuonResiduals5DOFFitter() override{}
 
   int type() const override { return MuonResidualsFitter::k5DOF; }
 

--- a/MuonAlignmentAlgorithms/interface/MuonResiduals6DOFFitter.h
+++ b/MuonAlignmentAlgorithms/interface/MuonResiduals6DOFFitter.h
@@ -61,7 +61,7 @@ public:
   };
 
   MuonResiduals6DOFFitter(int residualsModel, int minHits, int useResiduals, bool weightAlignment=true): MuonResidualsFitter(residualsModel, minHits, useResiduals, weightAlignment) {}
-  ~MuonResiduals6DOFFitter() {}
+  ~MuonResiduals6DOFFitter() override {}
 
   int type() const override { return MuonResidualsFitter::k6DOF; }
 

--- a/MuonAlignmentAlgorithms/interface/MuonResiduals6DOFrphiFitter.h
+++ b/MuonAlignmentAlgorithms/interface/MuonResiduals6DOFrphiFitter.h
@@ -56,11 +56,11 @@ public:
     MuonResidualsFitter(residualsModel, minHits, useResiduals, weightAlignment)  {}
 #endif
 
-  ~MuonResiduals6DOFrphiFitter() {}
+  ~MuonResiduals6DOFrphiFitter() override {}
 
   int type() const override { return MuonResidualsFitter::k6DOFrphi; }
 
-  int npar() override 
+  int npar() override
   {
     if (residualsModel() == kPureGaussian || residualsModel() == kPureGaussian2D || residualsModel() == kGaussPowerTails) return kNPar - 2;
     else if (residualsModel() == kPowerLawTails) return kNPar;

--- a/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
+++ b/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
@@ -80,7 +80,7 @@ class MuonAlignmentFromReference : public AlignmentAlgorithmBase{
   public:
 
     MuonAlignmentFromReference(const edm::ParameterSet& cfg);
-    virtual ~MuonAlignmentFromReference();
+    ~MuonAlignmentFromReference() override;
 
     void initialize(const edm::EventSetup& iSetup,
 	  AlignableTracker* alignableTracker,

--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@ Luca Pernie
 Dan Marley
 
 
-
 # Alignment
 
 
-The following describes the muon alignment setup and execution.
+The following describes the track-based muon alignment setup and execution.
 
 ## Setup your environment
 
 ```
+export RELEASE=CMSSW_10_0_0_pre2
 SCRAM_ARCH=slc6_amd64_gcc630; export SCRAM_ARCH;
-cmsrel CMSSW_9_4_0
-cd CMSSW_9_4_0/src/
+cmsrel $RELEASE
+cd $RELEASE/src/
 cmsenv
 
-git clone https://github.com/cms-mual/Alignment.git -b CMSSW_9_4_0
-git clone https://github.com/cms-mual/TrackingTools.git -b CMSSW_9_4_X
-git clone https://github.com/cms-mual/MuAlSupplementaryFiles.git -b CMSSW_9_0_X
+git clone https://github.com/cms-mual/Alignment.git -b $RELEASE
+git clone https://github.com/cms-mual/TrackingTools.git -b $RELEASE
+git clone https://github.com/cms-mual/MuAlSupplementaryFiles.git -b CMSSW_10_0_X
 cp MuAlSupplementaryFiles/* .
 
 ln -s Alignment/MuonAlignmentAlgorithms/scripts/createJobs.py
@@ -29,7 +29,7 @@ ln -s Alignment/MuonAlignmentAlgorithms/python/align_cfg.py
 ln -s Alignment/MuonAlignmentAlgorithms/scripts/submitBatchJobs.py
 ln -s Alignment/MuonAlignmentAlgorithms/scripts/runBatchJobMonitor.py
 
-scram b -j6
+scram b -j8
 ```
 
 
@@ -59,7 +59,7 @@ _NB: for CSC, the `--T0` option is not needed._
 ```
 
 Once the new shell script is created, simply execute the shell script to run the muon alignment.  
-_The new shell script should have the same name as the `-s` argument in the command above._
+_The new shell script should have the same name as the `-s` argument in the command above: 'data_DT-1100-111111_2017B_CMSSW925p2_SingMu_MuAlCalIsoMuv1_92XdataRun2Promptv5_T0.sh'_
 
 
 ### Run alignment on Simulation
@@ -114,7 +114,8 @@ python submitBatchJobs.py config.txt
 where `config.txt` is a configuration file that contains arguments similar to the command line arguments above.
 An example is located in `MuonAlignmentAlgorithms/scripts/config.txt`.  
 The `name` and `iterations` arguments are the only necessary configuration settings for submitting batch jobs.  
-_('name' is the same as the first argument above with the last `_`)_
+_(In the above command, 'name' = 'data_DT-1100-111111_2017B_CMSSW925p2_SingMu_MuAlCalIsoMuv1_92XdataRun2Promptv5_T0' 
+and 'iterations' is the number of iterations to run, the second argument in the above commands.)_
 
 Once the batch jobs have been submitted, the LSF ID numbers and corresponding scripts are saved to a file.  
 To check the successes or failures of batch jobs, run the following command:
@@ -138,45 +139,39 @@ For new releases of CMSSW, it is important to keep relevant code up-to-date.
 Currently, the muon alignment framework relies on CMSSW packages that aren't centrally maintained,
 but need to remain consistent with the official release.  
 
-First, get the correct architecture, checkout the release, if needed:
-```
-SCRAM_ARCH=slc6_amd64_gcc630
-export SCRAM_ARCH
-cmsrel CMSSW_9_3_0_pre5
-cd CMSSW_9_3_0_pre5/src/
-cmsenv
-```
+First, get the correct architecture, checkout the release, if needed, as described above.  
+Compare your local repository with the official CMSSW release.  
 
-Now, check the differences between your code and the one in the release.  
-If you are not sure about what should be different, 
-check the difference in the old release and the code you have locally there. 
+The repositories that need to be checked are:
 
-Those should be the the only difference you also have with the following command:
+- TrackingTools
+- Alignment/CommonAlignmentMonitor
+- Alignment/MuonAlignmentAlgorithms
 
+Directly compare your repository with the release using these commands:
 ```
-diff -r TrackingTools/TrackRefitter/ $CMSSW_RELEASE_BASE/src/TrackingTools/TrackRefitter/ > diff_TrackingTools.txt
+diff -r $CMSSW_BASE/src/TrackingTools/TrackRefitter/ $CMSSW_RELEASE_BASE/src/TrackingTools/TrackRefitter/ > diff_TrackingTools.txt
 ```
 In `TrackingTools` there should have only be one file with differences (where hits in muon system are neglected, and you do the fit 3 times).  
 Next, check the `CommonAlignmentMonitor`:
-
 ```
-diff -r Alignment/CommonAlignmentMonitor/ $CMSSW_RELEASE_BASE/src/Alignment/CommonAlignmentMonitor/ > diff_CommonAlignmentMonitor.txt
+diff -r $CMSSW_BASE/src/Alignment/CommonAlignmentMonitor/ $CMSSW_RELEASE_BASE/src/Alignment/CommonAlignmentMonitor/ > diff_CommonAlignmentMonitor.txt
 ```
-
 This package should be identical.  
-_For some reason this package must be mainted in `cms-mual`, so just check your version is identical to the one in the repository._
+_For some reason this package must be mainted in `cms-mual`, so just check your version is identical to the one in CMSSW._
 
 Finally, the `MuonAlignmentAlgorithms` package needs to be checked.
 ```
- diff -r ../../CMSSW_9_2_6/src/Alignment/MuonAlignmentAlgorithms/ /cvmfs/cms.cern.ch/slc6_amd64_gcc530/cms/cmssw-patch/CMSSW_9_2_5_patch2/src/Alignment/MuonAlignmentAlgorithms/ > diff_MuonAlignmentAlgorithms.txt
+ diff -r $CMSSW_BASE/src/Alignment/MuonAlignmentAlgorithms/ $CMSSW_RELEASE_BASE/src/Alignment/MuonAlignmentAlgorithms/ > diff_MuonAlignmentAlgorithms.txt
 ```
 
-There should be many dfferences here. 
-Check one by one if they are expected!  
-You can compare old release and new releases, and make the relevant changes in your code:
-
+There should be many dfferences here!  
+Check one by one if they are expected! If you are unsure if changes are expected,
+it is easiest to compare the two CMSSW releases and see what changes you need to propagate (rather than sifting through `diff_MuonAlignmentAlgorithms.txt`).
 ```
-diff -r $CMSSW_RELEASE_BASE/src/Alignment/MuonAlignmentAlgorithms/  /cvmfs/cms.cern.ch/slc6_amd64_gcc530/cms/cmssw-patch/CMSSW_9_2_6/src/Alignment/MuonAlignmentAlgorithms/ > diff_MuonAlignmentAlgorithms.txt
+export OLDRELEASE=CMSSW_9_4_0
+diff -r $CMSSW_RELEASE_BASE/src/Alignment/MuonAlignmentAlgorithms/  /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw-patch/$OLDRELEASE/src/Alignment/MuonAlignmentAlgorithms/ > diff_MuonAlignmentAlgorithms.txt
+# you may need to change the path to the old release, depending on CMSSW development.
 ```
 
 


### PR DESCRIPTION
Closes #19. This update brings the software up-to-date with CMSSW 10_0_0_pre2.  Minor changes between `9_4_0` and `10_0_0_pre2`.  Most updates to the README.